### PR TITLE
Palindrome 2024-04-21 v1

### DIFF
--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/.prettierrc
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "singleQuote": true
+}

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -1,3 +1,5 @@
+import { palindrome } from './index';
+
 describe('palindrome', () => {
   it('should return true if the input is a "mom"', () => {
     expect(palindrome('mom')).toBe(true);

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -1,37 +1,21 @@
 import { palindrome } from './index';
 
 describe('palindrome', () => {
-  it('should return true if the input is a "mom"', () => {
-    expect(palindrome('mom')).toBe(true);
-  });
-
-  it('should return true if the input is a "Mom"', () => {
-    expect(palindrome('Mom')).toBe(true);
-  });
-
-  it('should return true if the input is a "MoM"', () => {
-    expect(palindrome('MoM')).toBe(true);
-  });
-
-  it('should return false if the input is a "Was It A Rat I Saw"', () => {
-    expect(palindrome('Was It A Rat I Saw')).toBe(true);
-  });
-
-  it('should return false if the input is a "Never Odd or Even"', () => {
-    expect(palindrome('Never Odd or Even')).toBe(true);
-  });
-
-  it('should return false if the input is a "1Never Odd or Even1"', () => {
-    expect(palindrome('1Never Odd or Even1')).toBe(true);
-  });
-
-  // False cases
-
-  it('should return false if the input is a "Momx"', () => {
-    expect(palindrome('Momx')).toBe(false);
-  });
-
-  it('should return false if the input is a "Never Odd or Even1"', () => {
-    expect(palindrome('Never Odd or Even1')).toBe(false);
-  });
+  it.each`
+    input                    | expected
+    ${'mom'}                 | ${true}
+    ${'Mom'}                 | ${true}
+    ${'MoM'}                 | ${true}
+    ${'Momx'}                | ${false}
+    ${'xMomx'}               | ${true}
+    ${'Was It A Rat I Saw'}  | ${true}
+    ${'Never Odd or Even'}   | ${true}
+    ${'Never Odd or Even1'}  | ${false}
+    ${'1Never Odd or Even1'} | ${true}
+  `(
+    'should return $expected if the input is a "$input"',
+    ({ input, expected }) => {
+      expect(palindrome(input)).toBe(expected);
+    }
+  );
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -9,7 +9,11 @@ describe('palindrome', () => {
     expect(palindrome('Mom')).toBe(true);
   });
 
-  it('should return true if the input is a "Mom"', () => {
+  it('should return true if the input is a "MoM"', () => {
     expect(palindrome('MoM')).toBe(true);
+  });
+
+  it('should return false if the input is a "Momx"', () => {
+    expect(palindrome('Momx')).toBe(false);
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -16,4 +16,8 @@ describe('palindrome', () => {
   it('should return false if the input is a "Momx"', () => {
     expect(palindrome('Momx')).toBe(false);
   });
+
+  it('should return false if the input is a "Was It A Rat I Saw"', () => {
+    expect(palindrome('Was It A Rat I Saw')).toBe(true);
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -20,4 +20,8 @@ describe('palindrome', () => {
   it('should return false if the input is a "Was It A Rat I Saw"', () => {
     expect(palindrome('Was It A Rat I Saw')).toBe(true);
   });
+
+  it('should return false if the input is a "Never Odd or Even"', () => {
+    expect(palindrome('Never Odd or Even')).toBe(true);
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -8,4 +8,8 @@ describe('palindrome', () => {
   it('should return true if the input is a "Mom"', () => {
     expect(palindrome('Mom')).toBe(true);
   });
+
+  it('should return true if the input is a "Mom"', () => {
+    expect(palindrome('MoM')).toBe(true);
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -4,4 +4,8 @@ describe('palindrome', () => {
   it('should return true if the input is a "mom"', () => {
     expect(palindrome('mom')).toBe(true);
   });
+
+  it('should return true if the input is a "Mom"', () => {
+    expect(palindrome('Mom')).toBe(true);
+  });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -1,4 +1,5 @@
-
-describe('palindrome checker', () => {
-
-})
+describe('palindrome', () => {
+  it('should return true if the input is a "mom"', () => {
+    expect(palindrome('mom')).toBe(true);
+  });
+});

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.spec.ts
@@ -13,15 +13,25 @@ describe('palindrome', () => {
     expect(palindrome('MoM')).toBe(true);
   });
 
-  it('should return false if the input is a "Momx"', () => {
-    expect(palindrome('Momx')).toBe(false);
-  });
-
   it('should return false if the input is a "Was It A Rat I Saw"', () => {
     expect(palindrome('Was It A Rat I Saw')).toBe(true);
   });
 
   it('should return false if the input is a "Never Odd or Even"', () => {
     expect(palindrome('Never Odd or Even')).toBe(true);
+  });
+
+  it('should return false if the input is a "1Never Odd or Even1"', () => {
+    expect(palindrome('1Never Odd or Even1')).toBe(true);
+  });
+
+  // False cases
+
+  it('should return false if the input is a "Momx"', () => {
+    expect(palindrome('Momx')).toBe(false);
+  });
+
+  it('should return false if the input is a "Never Odd or Even1"', () => {
+    expect(palindrome('Never Odd or Even1')).toBe(false);
   });
 });

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -1,0 +1,13 @@
+// - [ ] I have committed on every single transition from red to green to refactor
+// - [ ] I have tests that validate the following statements
+//   - "mom" returns true
+//   - "Mom" returns true
+//   - "MoM" returns true
+//   - "Momx" returns false
+//   - "xMomx" returns true
+//   - "Was It A Rat I Saw" returns true
+//   - "Never Odd or Even" returns true
+//   - "Never Odd or Even1" returns false
+//   - "1Never Odd or Even1" returns true
+// - [ ] Once I have made the aforementioned tests pass, I have refactored my test specifications to use it.each() to perform parameterization (see Tip #3 here)
+// - [ ] There is no duplication in my test code or my production code

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -13,9 +13,8 @@
 // - [ ] There is no duplication in my test code or my production code
 
 export function palindrome(input: string): boolean {
-  if (input === 'Momx') {
-    return false;
-  }
+  const s = input.replace(/\s/g, '').toLowerCase();
+  const r = s.split('').reverse().join('');
 
-  return true;
+  return s === r;
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -1,5 +1,5 @@
-// - [ ] I have committed on every single transition from red to green to refactor
-// - [ ] I have tests that validate the following statements
+// - [x] I have committed on every single transition from red to green to refactor
+// - [x] I have tests that validate the following statements
 //   - "mom" returns true
 //   - "Mom" returns true
 //   - "MoM" returns true
@@ -9,8 +9,8 @@
 //   - "Never Odd or Even" returns true
 //   - "Never Odd or Even1" returns false
 //   - "1Never Odd or Even1" returns true
-// - [ ] Once I have made the aforementioned tests pass, I have refactored my test specifications to use it.each() to perform parameterization (see Tip #3 here)
-// - [ ] There is no duplication in my test code or my production code
+// - [x] Once I have made the aforementioned tests pass, I have refactored my test specifications to use it.each() to perform parameterization (see Tip #3 here)
+// - [x] There is no duplication in my test code or my production code
 
 export function palindrome(input: string): boolean {
   const s = input.replace(/\s/g, '').toLowerCase();

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -13,5 +13,9 @@
 // - [ ] There is no duplication in my test code or my production code
 
 export function palindrome(input: string): boolean {
+  if (input === 'Momx') {
+    return false;
+  }
+
   return true;
 }

--- a/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
+++ b/ThePhasesOfCraftship/2_best_practice_first/testingBasics/exercises/1_Red_Green_Refactor/1_2_Palindrome/src/index.ts
@@ -11,3 +11,7 @@
 //   - "1Never Odd or Even1" returns true
 // - [ ] Once I have made the aforementioned tests pass, I have refactored my test specifications to use it.each() to perform parameterization (see Tip #3 here)
 // - [ ] There is no duplication in my test code or my production code
+
+export function palindrome(input: string): boolean {
+  return true;
+}


### PR DESCRIPTION
- [x] I have committed on every single transition from red to green to refactor
- [x] I have tests that validate the following statements
  - "mom" returns true
  - "Mom" returns true
  - "MoM" returns true
  - "Momx" returns false
  - "xMomx" returns true
  - "Was It A Rat I Saw" returns true
  - "Never Odd or Even" returns true
  - "Never Odd or Even1" returns false
  - "1Never Odd or Even1" returns true
- [x] Once I have made the aforementioned tests pass, I have refactored my test specifications to use it.each() to perform parameterization (see Tip #3 here)
- [x] There is no duplication in my test code or my production code